### PR TITLE
fixed jquery version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0",
     "firebase": "^2.1.0",


### PR DESCRIPTION
I'm new to Ember so maybe there is a better solution.

But basically, the ember and jquery versions are incompatible. 

http://stackoverflow.com/questions/34702284/getting-uncaught-error-assertion-failed-ember-views-require-jquery-between-1

Users would also have to call bower "install explicitly".